### PR TITLE
Update link to Digital Bodleian version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See this Wiki page for instructions on how to use the IIIF manifest editor:
 
 ## Online Demo
 You can find online demos of the IIIF Manifest Editor here:
-* [https://iiif.bodleian.ox.ac.uk/manifest-editor/](http://iiif.bodleian.ox.ac.uk/manifest-editor/)
+* [https://digital.bodleian.ox.ac.uk/manifest-editor/](http://digital.bodleian.ox.ac.uk/manifest-editor/)
 * [https://iiif-manifest-editor.textandbytes.com/](https://iiif-manifest-editor.textandbytes.com/)
 
 ## How to set up the application ##


### PR DESCRIPTION
'cos `master` is ahead of `develop` by this one commit.

> I've just cherry-picked @ahankinson 's work 😄 

There's no contributing guide so I _think_ this is kosher: it syncs `develop` with `master` and means I can then feature branch off `develop`.